### PR TITLE
Return empty CodeLens instead of failing

### DIFF
--- a/server.go
+++ b/server.go
@@ -68,8 +68,8 @@ func (s *server) CodeAction(context.Context, *protocol.CodeActionParams) ([]prot
 	return nil, notImplemented("CodeAction")
 }
 
-func (s *server) CodeLens(context.Context, *protocol.CodeLensParams) ([]protocol.CodeLens, error) {
-	return nil, notImplemented("CodeLens")
+func (s *server) CodeLens(ctx context.Context, params *protocol.CodeLensParams) ([]protocol.CodeLens, error) {
+	return []protocol.CodeLens{}, nil
 }
 
 func (s *server) CodeLensRefresh(context.Context) error {


### PR DESCRIPTION
vscode is going crazy trying to get CodeLens
Returning an empty array fixes that issue