### PR TITLE
Add full language support in the VS Code plugin

### DIFF
--- a/editor/vscode-client/language/README.md
+++ b/editor/vscode-client/language/README.md
@@ -1,0 +1,3 @@
+# Credits
+
+Originally from <https://github.com/heptio/vscode-jsonnet>. Modified to add new stdlib functions

--- a/editor/vscode-client/language/configuration.jsonc
+++ b/editor/vscode-client/language/configuration.jsonc
@@ -1,0 +1,84 @@
+{
+    "comments": {
+        "lineComment": "//",
+        "blockComment": [
+            "/*",
+            "*/"
+        ]
+    },
+    // Symbols used as brackets.
+    "brackets": [
+        [
+            "{",
+            "}"
+        ],
+        [
+            "[",
+            "]"
+        ],
+        [
+            "(",
+            ")"
+        ]
+    ],
+    // Symbols that are auto closed when typing.
+    "autoClosingPairs": [
+        {
+            "open": "{",
+            "close": "}"
+        },
+        {
+            "open": "[",
+            "close": "]"
+        },
+        {
+            "open": "(",
+            "close": ")"
+        },
+        {
+            "open": "'",
+            "close": "'",
+            "notIn": [
+                "string",
+                "comment"
+            ]
+        },
+        {
+            "open": "\"",
+            "close": "\"",
+            "notIn": [
+                "string"
+            ]
+        },
+        {
+            "open": "/**",
+            "close": " */",
+            "notIn": [
+                "string"
+            ]
+        }
+    ],
+    // Symbols that that can be used to surround a selection.
+    "surroundingPairs": [
+        [
+            "{",
+            "}"
+        ],
+        [
+            "[",
+            "]"
+        ],
+        [
+            "(",
+            ")"
+        ],
+        [
+            "\"",
+            "\""
+        ],
+        [
+            "'",
+            "'"
+        ]
+    ]
+}

--- a/editor/vscode-client/language/jsonnet.tmLanguage.json
+++ b/editor/vscode-client/language/jsonnet.tmLanguage.json
@@ -1,0 +1,246 @@
+{
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "name": "Jsonnet",
+    "patterns": [
+        {
+            "include": "#expression"
+        },
+        {
+            "include": "#keywords"
+        }
+    ],
+    "repository": {
+        "builtin-functions": {
+            "comment": "Functions from: https://jsonnet.org/ref/stdlib.html",
+            "patterns": [
+                {
+                    "comment": "External Variables",
+                    "match": "\\bstd[.]extVar\\b",
+                    "name": "support.function.jsonnet"
+                },
+                {
+                    "comment": "Types and Reflection",
+                    "match": "\\bstd[.](thisFile|type|length|get|objectHas|objectFields|objectValues|objectHasAll|objectFieldsAll|objectValuesAll|prune|mapWithKey)\\b",
+                    "name": "support.function.jsonnet"
+                },
+                {
+                    "comment": "Mathematical Utilities 1",
+                    "match": "\\bstd[.](abs|sign|max|min|pow|exp|log|exponent|mantissa|floor|ceil|sqrt|sin|cos|tan|asin|acos|atan)\\b",
+                    "name": "support.function.jsonnet"
+                },
+                {
+                    "comment": "Mathematical Utilities 2",
+                    "match": "\\bstd[.]clamp\\b",
+                    "name": "support.function.jsonnet"
+                },
+                {
+                    "comment": "Assertions and Debugging",
+                    "match": "\\bstd[.]assertEqual\\b",
+                    "name": "support.function.jsonnet"
+                },
+                {
+                    "comment": "String Manipulation",
+                    "match": "\\bstd[.](toString|codepoint|char|substr|findSubstr|startsWith|endsWith|stripChars|lstripChars|rstripChars|split|splitLimit|strReplace|asciiUpper|asciiLower|stringChars|format|escapeStringBash|escapeStringDollars|escapeStringJson|escapeStringPython)\\b",
+                    "name": "support.function.jsonnet"
+                },
+                {
+                    "comment": "Parsing 1",
+                    "match": "\\bstd[.]parse(Int|Octal|Hex|Json|Yaml)\\b",
+                    "name": "support.function.jsonnet"
+                },
+                {
+                    "comment": "Parsing 2",
+                    "match": "\\bstd[.](encodeUTF8|decodeUTF8)\\b",
+                    "name": "support.function.jsonnet"
+                },
+                {
+                    "comment": "Manifestation",
+                    "match": "\\bstd[.]manifest(Ini|Python|PythonVars|JsonEx|JsonMinified|YamlDoc|YamlStream|XmlJsonml|TomlEx)\\b",
+                    "name": "support.function.jsonnet"
+                },
+                {
+                    "comment": "Arrays",
+                    "match": "\\bstd[.](makeArray|member|count|find|map|mapWithIndex|filterMap|flatMap|filter|foldl|foldr|range|repeat|slice|join|lines|flattenArrays|reverse|sort|uniq)\\b",
+                    "name": "support.function.jsonnet"
+                },
+                {
+                    "comment": "Sets",
+                    "match": "\\bstd[.]set(Inter|Union|Diff|Member)?\\b",
+                    "name": "support.function.jsonnet"
+                },
+                {
+                    "comment": "Encoding",
+                    "match": "\\bstd[.](base64|base64DecodeBytes|base64Decode|md5)\\b",
+                    "name": "support.function.jsonnet"
+                },
+                {
+                    "comment": "JSON Merge Patch",
+                    "match": "\\bstd[.]mergePatch\\b",
+                    "name": "support.function.jsonnet"
+                },
+                {
+                    "comment": "Debugging",
+                    "match": "\\bstd[.]trace\\b",
+                    "name": "support.function.jsonnet"
+                }
+            ]
+        },
+        "comment": {
+            "patterns": [
+                {
+                    "begin": "/\\*",
+                    "end": "\\*/",
+                    "name": "comment.block.jsonnet"
+                },
+                {
+                    "match": "//.*$",
+                    "name": "comment.line.jsonnet"
+                },
+                {
+                    "match": "#.*$",
+                    "name": "comment.block.jsonnet"
+                }
+            ]
+        },
+        "double-quoted-strings": {
+            "begin": "\"",
+            "end": "\"",
+            "name": "string.quoted.double.jsonnet",
+            "patterns": [
+                {
+                    "match": "\\\\([\"\\\\/bfnrt]|(u[0-9a-fA-F]{4}))",
+                    "name": "constant.character.escape.jsonnet"
+                },
+                {
+                    "match": "\\\\[^\"\\\\/bfnrtu]",
+                    "name": "invalid.illegal.jsonnet"
+                }
+            ]
+        },
+        "expression": {
+            "patterns": [
+                {
+                    "include": "#literals"
+                },
+                {
+                    "include": "#comment"
+                },
+                {
+                    "include": "#single-quoted-strings"
+                },
+                {
+                    "include": "#double-quoted-strings"
+                },
+                {
+                    "include": "#triple-quoted-strings"
+                },
+                {
+                    "include": "#builtin-functions"
+                },
+                {
+                    "include": "#functions"
+                }
+            ]
+        },
+        "functions": {
+            "patterns": [
+                {
+                    "begin": "\\b([a-zA-Z_][a-z0-9A-Z_]*)\\s*\\(",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "entity.name.function.jsonnet"
+                        }
+                    },
+                    "end": "\\)",
+                    "name": "meta.function",
+                    "patterns": [
+                        {
+                            "include": "#expression"
+                        }
+                    ]
+                }
+            ]
+        },
+        "keywords": {
+            "patterns": [
+                {
+                    "match": "[!:~\\+\\-&\\|\\^=<>\\*\\/%]",
+                    "name": "keyword.operator.jsonnet"
+                },
+                {
+                    "match": "\\$",
+                    "name": "keyword.other.jsonnet"
+                },
+                {
+                    "match": "\\b(self|super|import|importstr|local|tailstrict)\\b",
+                    "name": "keyword.other.jsonnet"
+                },
+                {
+                    "match": "\\b(if|then|else|for|in|error|assert)\\b",
+                    "name": "keyword.control.jsonnet"
+                },
+                {
+                    "match": "\\b(function)\\b",
+                    "name": "storage.type.jsonnet"
+                },
+                {
+                    "match": "[a-zA-Z_][a-z0-9A-Z_]*\\s*(:::|\\+:::)",
+                    "name": "variable.parameter.jsonnet"
+                },
+                {
+                    "match": "[a-zA-Z_][a-z0-9A-Z_]*\\s*(::|\\+::)",
+                    "name": "entity.name.type"
+                },
+                {
+                    "match": "[a-zA-Z_][a-z0-9A-Z_]*\\s*(:|\\+:)",
+                    "name": "variable.parameter.jsonnet"
+                }
+            ]
+        },
+        "literals": {
+            "patterns": [
+                {
+                    "match": "\\b(true|false|null)\\b",
+                    "name": "constant.language.jsonnet"
+                },
+                {
+                    "match": "\\b(\\d+([Ee][+-]?\\d+)?)\\b",
+                    "name": "constant.numeric.jsonnet"
+                },
+                {
+                    "match": "\\b\\d+[.]\\d*([Ee][+-]?\\d+)?\\b",
+                    "name": "constant.numeric.jsonnet"
+                },
+                {
+                    "match": "\\b[.]\\d+([Ee][+-]?\\d+)?\\b",
+                    "name": "constant.numeric.jsonnet"
+                }
+            ]
+        },
+        "single-quoted-strings": {
+            "begin": "'",
+            "end": "'",
+            "name": "string.quoted.double.jsonnet",
+            "patterns": [
+                {
+                    "match": "\\\\(['\\\\/bfnrt]|(u[0-9a-fA-F]{4}))",
+                    "name": "constant.character.escape.jsonnet"
+                },
+                {
+                    "match": "\\\\[^'\\\\/bfnrtu]",
+                    "name": "invalid.illegal.jsonnet"
+                }
+            ]
+        },
+        "triple-quoted-strings": {
+            "patterns": [
+                {
+                    "begin": "\\|\\|\\|",
+                    "end": "\\|\\|\\|",
+                    "name": "string.quoted.triple.jsonnet"
+                }
+            ]
+        }
+    },
+    "scopeName": "source.jsonnet"
+}

--- a/editor/vscode-client/package-lock.json
+++ b/editor/vscode-client/package-lock.json
@@ -8,6 +8,10 @@
 			"name": "jsonnet-lsp",
 			"version": "0.0.1",
 			"license": "AGPLv3",
+			"dependencies": {
+				"@types/vscode": "^1.61.0",
+				"vscode-languageclient": "^7.0.0"
+			},
 			"devDependencies": {
 				"@types/node": "^12.12.0",
 				"@typescript-eslint/eslint-plugin": "^4.23.0",
@@ -1941,7 +1945,8 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "https://registry.npmjs.org/@types/vscode/-/vscode-1.61.0.tgz",
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.61.0.tgz",
 			"integrity": "sha512-9k5Nwq45hkRwdfCFY+eKXeQQSbPoA114mF7U/4uJXRBJeGIO7MuJdhF1PnaDN+lllL9iKGQtd6FFXShBXMNaFg=="
 		},
 		"@typescript-eslint/eslint-plugin": {
@@ -3007,7 +3012,8 @@
 			"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
 		},
 		"vscode-languageclient": {
-			"version": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
 			"integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
 			"requires": {
 				"minimatch": "^3.0.4",

--- a/editor/vscode-client/package.json
+++ b/editor/vscode-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsonnet-lsp",
-	"description": "Code navigation for Jsonnet. Use in combination with https://github.com/liamdawson/vscode-jsonnet-language",
+	"description": "Full code support (formatting, highlighting, navigation, etc) for Jsonnet",
 	"license": "AGPLv3",
 	"version": "0.0.1",
 	"publisher": "grafana",
@@ -18,6 +18,27 @@
 	],
 	"main": "./out/extension",
 	"contributes": {
+		"languages": [
+			{
+				"id": "jsonnet",
+				"aliases": [
+					"Jsonnet",
+					"jsonnet"
+				],
+				"extensions": [
+					".jsonnet",
+					".libsonnet"
+				],
+				"configuration": "./language/configuration.jsonc"
+			}
+		],
+		"grammars": [
+			{
+				"language": "jsonnet",
+				"scopeName": "source.jsonnet",
+				"path": "./language/jsonnet.tmLanguage.json"
+			}
+		],
 		"configuration": {
 			"type": "object",
 			"title": "Jsonnet Language Server",
@@ -56,6 +77,6 @@
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -b",
 		"watch": "tsc -b -w",
-		"lint": "eslint ./src --ext .ts,.tsx",
+		"lint": "eslint ./src --ext .ts,.tsx"
 	}
 }

--- a/editor/vscode-client/src/extension.ts
+++ b/editor/vscode-client/src/extension.ts
@@ -47,8 +47,8 @@ export function activate(context: ExtensionContext) {
 
 	// Create the language client and start the client.
 	client = new LanguageClient(
-		'languageServerExample',
-		'Language Server Example',
+		'jsonnetLanguageServer',
+		'Jsonnet Language Server',
 		serverOptions,
 		clientOptions
 	);


### PR DESCRIPTION
Adds (and improves) the language configuration from https://github.com/liamdawson/vscode-jsonnet-language (which took it from https://github.com/heptio/vscode-jsonnet)
This makes this vscode plugin fully support the jsonnet language without any dependencies

I want to make this releasable in vscode ASAP so I can start testing iteratively (in real cases, not a development instance). With formatting and the navigation it currently has, it's already much better than the alternatives

Next steps:
1. Make the vscode extension download the latest language server release automatically
1. Release the jsonnet language server in a Github Actions upon tagging
1. Release and publish the vscode plugin in a Github Actions upon tagging