### PR TITLE
fix: typo in `file://` for import definitions

### DIFF
--- a/server.go
+++ b/server.go
@@ -164,7 +164,7 @@ func (s *server) Definition(ctx context.Context, params *protocol.DefinitionPara
 						fmt.Fprintln(os.Stderr, err)
 						return nil, err
 					}
-					return protocol.Definition{{URI: "file:///" + protocol.DocumentURI(foundAt)}}, nil
+					return protocol.Definition{{URI: "file://" + protocol.DocumentURI(foundAt)}}, nil
 				}
 
 				// The point is on a variable, the definition of which is the first definition


### PR DESCRIPTION
I'm guessing it works in Emacs, but with the typo, definitions were completely broken for vscode
All good now!

Signed-off-by: Julien Duchesne <julien.duchesne@grafana.com>