### PR TITLE
feat: Front the server with a CLI

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,10 @@ buildGoModule rec {
   pname = "jsonnet-language-server";
   version = "0.2.1";
 
+  buildFlagsArray = ''
+    -ldflags=
+    -X main.version=${version}
+  '';
   src = lib.cleanSource ./.;
   vendorSha256 = "sha256-8jX2we1fpVmjhwcaLZ584MdbkvnrcDNAw9xKhT/z740=";
 

--- a/main.go
+++ b/main.go
@@ -19,14 +19,70 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/jdbaldry/go-language-server-protocol/jsonrpc2"
 	"github.com/jdbaldry/go-language-server-protocol/lsp/protocol"
 )
 
+const (
+	name = "jsonnet-language-server"
+)
+
+var (
+	// Set with `-ldflags="-X 'main.version=<version>'"`
+	version = "dev"
+)
+
+// printVersion prints version text to the provided writer.
+func printVersion(w io.Writer) {
+	fmt.Fprintf(w, "%s version %s\n", name, version)
+}
+
+// printVersion prints help text to the provided writer.
+func printHelp(w io.Writer) {
+	printVersion(w)
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Options:\n")
+	fmt.Fprintf(w, "  -h / --help        Print this help message.\n")
+	fmt.Fprintf(w, "  -J / --jpath <dir> Specify an additional library search dir\n")
+	fmt.Fprintf(w, "                     (right-most wins).\n")
+	fmt.Fprintf(w, "  -v / --version     Print version.\n")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Environment variables:\n")
+	fmt.Fprintf(w, "  JSONNET_PATH is a %q separated list of directories\n", filepath.ListSeparator)
+	fmt.Fprintf(w, "  added in reverse order before the paths specified by --jpath.\n")
+	fmt.Fprintf(w, "  These are equivalent:\n")
+	fmt.Fprintf(w, "    JSONNET_PATH=a:b %s -J c -J d\n", name)
+	fmt.Fprintf(w, "    JSONNET_PATH=d:c:a:b %s\n", name)
+	fmt.Fprintf(w, "    %s -J b -J a -J c -J d\n", name)
+}
+
 func main() {
+	jpaths := filepath.SplitList(os.Getenv("JSONNET_PATH"))
+
+	for i, arg := range os.Args {
+		if arg == "-h" || arg == "--help" {
+			printHelp(os.Stdout)
+			os.Exit(0)
+		} else if arg == "-v" || arg == "--version" {
+			printVersion(os.Stdout)
+			os.Exit(0)
+		} else if arg == "-J" || arg == "--jpath" {
+			if i == len(os.Args)-1 {
+				fmt.Printf("Expected value for option %s but found none.\n", arg)
+				fmt.Println()
+				printHelp(os.Stdout)
+				os.Exit(1)
+			}
+
+			jpaths = append([]string{os.Args[i+1]}, jpaths...)
+		}
+	}
+
 	log.Println("Starting the language server")
 
 	ctx := context.Background()
@@ -34,7 +90,7 @@ func main() {
 	conn := jsonrpc2.NewConn(stream)
 	client := protocol.ClientDispatcher(conn)
 
-	s, err := newServer(client)
+	s, err := newServer(client, jpaths)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}

--- a/main.go
+++ b/main.go
@@ -18,8 +18,8 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -38,19 +38,18 @@ var (
 )
 
 // printVersion prints version text to the provided writer.
-func printVersion(w io.Writer) {
+func printVersion() {
+	w := flag.CommandLine.Output()
 	fmt.Fprintf(w, "%s version %s\n", name, version)
 }
 
 // printVersion prints help text to the provided writer.
-func printHelp(w io.Writer) {
-	printVersion(w)
+func printHelp() {
+	w := flag.CommandLine.Output()
+
+	printVersion()
 	fmt.Fprintln(w)
-	fmt.Fprintf(w, "Options:\n")
-	fmt.Fprintf(w, "  -h / --help        Print this help message.\n")
-	fmt.Fprintf(w, "  -J / --jpath <dir> Specify an additional library search dir\n")
-	fmt.Fprintf(w, "                     (right-most wins).\n")
-	fmt.Fprintf(w, "  -v / --version     Print version.\n")
+	flag.PrintDefaults()
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "Environment variables:\n")
 	fmt.Fprintf(w, "  JSONNET_PATH is a %q separated list of directories\n", filepath.ListSeparator)
@@ -64,24 +63,17 @@ func printHelp(w io.Writer) {
 func main() {
 	jpaths := filepath.SplitList(os.Getenv("JSONNET_PATH"))
 
-	for i, arg := range os.Args {
-		if arg == "-h" || arg == "--help" {
-			printHelp(os.Stdout)
-			os.Exit(0)
-		} else if arg == "-v" || arg == "--version" {
-			printVersion(os.Stdout)
-			os.Exit(0)
-		} else if arg == "-J" || arg == "--jpath" {
-			if i == len(os.Args)-1 {
-				fmt.Printf("Expected value for option %s but found none.\n", arg)
-				fmt.Println()
-				printHelp(os.Stdout)
-				os.Exit(1)
-			}
+	flag.Usage = printHelp
+	versionArg := flag.Bool("version", false, "Print version and exit")
+	jpathArg := flag.String("jpath", "", "Specify an additional library search dir (right-most wins)")
+	flag.Parse()
 
-			jpaths = append([]string{os.Args[i+1]}, jpaths...)
-		}
+	if *versionArg {
+		printVersion()
+		os.Exit(0)
 	}
+
+	jpaths = append([]string{*jpathArg}, jpaths...)
 
 	log.Println("Starting the language server")
 

--- a/server.go
+++ b/server.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -47,8 +46,7 @@ var (
 )
 
 // newServer returns a new language server.
-func newServer(client protocol.ClientCloser) (*server, error) {
-	jpaths := filepath.SplitList(os.Getenv("JSONNET_PATH"))
+func newServer(client protocol.ClientCloser, jpaths []string) (*server, error) {
 	log.Printf("Using the following jpaths: %v", jpaths)
 
 	// TODO(#32): The language server VM has no support for Top Level Arguments (TLAs).


### PR DESCRIPTION
Opening this as a point of discussion
For the vscode extension, I'd like to download/update to the latest released version (with a user prompt).
For this, I need to know the currently installed version. Having a CLI `--version` allows me to query that
It also provides a central configuration entrypoint for current and future options

If you think this is a good idea, I can then set up CI to create releases on tags and publish executables (with goreleaser) and the release process can be configured to pass the correct ldflags

Signed-off-by: Julien Duchesne <julien.duchesne@grafana.com>